### PR TITLE
fix cookie namespace

### DIFF
--- a/src/SymfonyIntegration.php
+++ b/src/SymfonyIntegration.php
@@ -3,6 +3,7 @@
 namespace updg\roadrunner\symfony;
 
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;


### PR DESCRIPTION
Error: Class 'updg\roadrunner\symfony\Cookie' not found in S:\OSPanel\domains\amasty-report.loc\vendor\updg\roadrunner-symfony\src\SymfonyIntegration.php:121